### PR TITLE
Add support of Force boolean flag

### DIFF
--- a/body.txt
+++ b/body.txt
@@ -16,6 +16,7 @@ ifnempty(`_SERVICELOGIN', `         <d:ServiceLogin>_SERVICELOGIN</d:ServiceLogi
 ifnempty(`_SERVICEPASSWORD', `         <d:ServicePassword>_SERVICEPASSWORD</d:ServicePassword>', `dnl')
 ifnempty(`_CURSOR', `         <d:Cursor>_CURSOR</d:Cursor>', `dnl')
 ifnempty(`_PAGESIZE', `         <d:PageSize>_PAGESIZE</d:PageSize>', `dnl')
+ifnempty(`_FORCE', `         <d:Force>_FORCE</d:Force>', `dnl')
       </m:properties>
    </content>
 </entry>

--- a/example_create
+++ b/example_create
@@ -1,2 +1,2 @@
 
-./createSynchronizer -D_SCHEDULE="0 */3 * * * ?" -D_REQUEST=stop -D_SERVICEURL="http://192.168.0.105:8080/odata/v1" -D_LABEL=my_user_syncer -D_SERVICELOGIN=root -D_SERVICEPASSWORD=a
+./createSynchronizer -D_SCHEDULE="0 */3 * * * ?" -D_REQUEST=stop -D_SERVICEURL="http://192.168.0.105:8080/odata/v1" -D_LABEL=my_user_syncer -D_SERVICELOGIN=root -D_SERVICEPASSWORD=a -D_FORCE=false | xmllint --format -


### PR DESCRIPTION
Force boolean (false|true) flag has been added in OData user synchronizer
since DHuS V0.9.0-hotfix-3. The Force flag aims to perform synchronization
of users with username only when true. Otherwise, the matching of the user
if performed according to the username and the date of creation of the user.

I also added xml shell formatter to help user to easier read odata xml outputs.